### PR TITLE
パンくずリスト実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,3 +67,4 @@ gem 'pry-rails'
 gem 'haml-rails'
 gem 'erb2haml'
 gem 'active_hash'
+gem "gretel"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,8 @@ GEM
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (3.0.9)
+      rails (>= 3.1.0)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -328,6 +330,7 @@ DEPENDENCIES
   fog-aws
   font-awesome-rails
   font-awesome-sass (~> 5.4.1)
+  gretel
   haml-rails
   jbuilder (~> 2.7)
   jquery-rails

--- a/app/views/articles/show.html.haml
+++ b/app/views/articles/show.html.haml
@@ -1,4 +1,6 @@
 .article-show
+  - breadcrumb :article
+  = render "layouts/breadcrumbs"
   .article-show__left
     .article-show__left__heading
       .article-show__left__heading--title
@@ -18,11 +20,6 @@
         - @article.pictures.each do |picture|
           .article-show__left__albums__box--album
             = image_tag (picture.image.url)
-        -# .article-show__left__albums__box--album 2
-        -# .article-show__left__albums__box--album 3
-        -# .article-show__left__albums__box--album 4
-        -# .article-show__left__albums__box--album 5
-        -# .article-show__left__albums__box--album もっと見る
     = link_to "このスポットに写真投稿", new_picture_path(@article)
     = link_to "もっとみる", ""
   .article-show__right

--- a/app/views/layouts/_breadcrumbs.html.haml
+++ b/app/views/layouts/_breadcrumbs.html.haml
@@ -1,0 +1,2 @@
+.breadcrumbs
+  = breadcrumbs pretext: "",separator: " &rsaquo; ", class: "breadcrumbs-list"

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,31 @@
+crumb :root do
+  link "トップページ", root_path
+end
+
+crumb :article do
+  link "記事", article_path
+end
+# crumb :projects do
+#   link "Projects", projects_path
+# end
+
+# crumb :project do |project|
+#   link project.name, project_path(project)
+#   parent :projects
+# end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).


### PR DESCRIPTION
#What
・パンくずリストを実装

#Why
・現在のページの位置がすぐにわかる。
・一つ前のページに簡単に戻れるようにするため。